### PR TITLE
シーン切り替えによるリスタート処理を追加

### DIFF
--- a/UniSideGame/Assets/Scenes/ChangeScene.cs
+++ b/UniSideGame/Assets/Scenes/ChangeScene.cs
@@ -1,0 +1,27 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public class ChangeScene : MonoBehaviour
+{
+    public string sceneName;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+
+    // シーンを読み込む
+    public void Load()
+    {
+        SceneManager.LoadScene(sceneName);
+    }
+}

--- a/UniSideGame/Assets/Scenes/ChangeScene.cs.meta
+++ b/UniSideGame/Assets/Scenes/ChangeScene.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8683ab77b929d4843805337ff20dcb8a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UniSideGame/Assets/Scenes/GameManager.cs
+++ b/UniSideGame/Assets/Scenes/GameManager.cs
@@ -68,8 +68,6 @@ public class GameManager : MonoBehaviour
     // 画像を非表示にする
     void InactiveImage()
     {
-        mainImage.GetComponent<Image>().sprite = gameStartSpr;
-        
-        // mainImage.SetActive(false);
+        mainImage.SetActive(false);
     }
 }

--- a/UniSideGame/Assets/Scenes/Stage1.unity
+++ b/UniSideGame/Assets/Scenes/Stage1.unity
@@ -789,6 +789,7 @@ GameObject:
   - component: {fileID: 1454042455}
   - component: {fileID: 1454042454}
   - component: {fileID: 1454042453}
+  - component: {fileID: 1454042456}
   m_Layer: 5
   m_Name: NextButton
   m_TagString: Untagged
@@ -859,7 +860,19 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1454042454}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 1454042456}
+        m_TargetAssemblyTypeName: ChangeScene, Assembly-CSharp
+        m_MethodName: Load
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &1454042454
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -898,6 +911,19 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1454042451}
   m_CullTransparentMesh: 1
+--- !u!114 &1454042456
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1454042451}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8683ab77b929d4843805337ff20dcb8a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sceneName: Stage2
 --- !u!1 &1510033447
 GameObject:
   m_ObjectHideFlags: 0
@@ -1128,6 +1154,7 @@ GameObject:
   - component: {fileID: 1952861039}
   - component: {fileID: 1952861038}
   - component: {fileID: 1952861037}
+  - component: {fileID: 1952861040}
   m_Layer: 5
   m_Name: RestartButton
   m_TagString: Untagged
@@ -1198,7 +1225,19 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1952861038}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 1952861040}
+        m_TargetAssemblyTypeName: ChangeScene, Assembly-CSharp
+        m_MethodName: Load
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &1952861038
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1237,6 +1276,19 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1952861035}
   m_CullTransparentMesh: 1
+--- !u!114 &1952861040
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1952861035}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8683ab77b929d4843805337ff20dcb8a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sceneName: Stage1
 --- !u!1001 &2034805723
 PrefabInstance:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
# Scenemanagementの追加
ゲームオーバー時、RESTARTボタンクリックでシーンを切り替え
同ステージをリスタート出来るようにした。

ステージ追加が未実装なので、NEXT STAGEボタンについては別タスクで対応。